### PR TITLE
為了防止濫用我們將問問題的FC提高到70

### DIFF
--- a/index.js
+++ b/index.js
@@ -892,9 +892,9 @@ client.on("interactionCreate", async (interaction) => {
 			await interaction.followUp(`你要付給別人.....多少錢?蛤?`);
 			return;
 		}
-		if (amount < 15) {
+		if (amount < 70) {
 			await interaction.followUp(
-				`太少了啦，至少要超過 15 <:freecoin:1171871969617117224> 。`
+				`太少了啦，至少要超過 70 <:freecoin:1171871969617117224> 。`
 			);
 			return;
 		}


### PR DESCRIPTION
為了防止功能的濫用，我們決定將問問題的FC（問答獎勵）門檻提高至70。這樣的調整旨在確保只有達到一定參與度或貢獻度的用戶才能使用該功能。由於過去曾出現過一些用戶頻繁或惡意提問的情況，這不僅影響了其他用戶的正常使用，也對系統資源造成了一定壓力。因此，我們希望通過提高FC門檻，鼓勵更負責任的使用行為，同時維護平台的公平性和穩定性，為所有用戶提供更好的服務體驗。